### PR TITLE
Changes to SVO for modern building.

### DIFF
--- a/svo/src/bundle_adjustment.cpp
+++ b/svo/src/bundle_adjustment.cpp
@@ -88,9 +88,9 @@ void twoViewBA(
   printf("2-View BA: Error before/after = %f / %f\n", init_error, final_error);
 
   // Update Keyframe Positions
-  frame1->T_f_w_.rotation_matrix() = v_frame1->estimate().rotation().toRotationMatrix();
+  frame1->T_f_w_.setRotationMatrix(v_frame1->estimate().rotation().toRotationMatrix());
   frame1->T_f_w_.translation() = v_frame1->estimate().translation();
-  frame2->T_f_w_.rotation_matrix() = v_frame2->estimate().rotation().toRotationMatrix();
+  frame2->T_f_w_.setRotationMatrix(v_frame2->estimate().rotation().toRotationMatrix());
   frame2->T_f_w_.translation() = v_frame2->estimate().translation();
 
   // Update Mappoint Positions

--- a/svo/test/test_pipeline.cpp
+++ b/svo/test/test_pipeline.cpp
@@ -26,7 +26,7 @@
 #include <vikit/atan_camera.h>
 #include <vikit/pinhole_camera.h>
 #include <opencv2/opencv.hpp>
-#include <sophus/se3.h>
+#include <sophus/se3.hpp>
 #include <iostream>
 #include "test_utils.h"
 


### PR DESCRIPTION
In bundle_adjustment, call .setRotationMatrix instead of assigning to
rotation_matrix()

In test_pipeline, Sophus includes are now .hpp instead of .h
